### PR TITLE
feat(integrations): add Zod schema validation

### DIFF
--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@faktoor/zod",
+  "version": "0.0.1",
+  "description": "Zod validation schemas for faktoor.js",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist coverage .turbo"
+  },
+  "keywords": [
+    "email",
+    "mail",
+    "faktoor",
+    "zod",
+    "validation",
+    "schema",
+    "typescript"
+  ],
+  "author": "Youssef Bouhjira",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ybouhjira/faktoor.js.git",
+    "directory": "packages/zod"
+  },
+  "peerDependencies": {
+    "zod": "^3.0.0"
+  },
+  "devDependencies": {
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8",
+    "zod": "^3.24.0"
+  }
+}

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1,0 +1,114 @@
+import { z } from 'zod';
+
+/**
+ * Schema for email addresses with optional display name
+ */
+export const AddressSchema = z.object({
+  email: z.string().email('Invalid email address'),
+  name: z.string().optional(),
+});
+
+export type AddressInput = z.infer<typeof AddressSchema>;
+
+/**
+ * Schema for attachment input when sending emails
+ */
+export const AttachmentInputSchema = z
+  .object({
+    filename: z.string().min(1, 'Filename is required'),
+    content: z
+      .union([z.instanceof(ArrayBuffer), z.instanceof(Uint8Array), z.string()])
+      .optional(),
+    path: z.string().optional(),
+    mimeType: z.string().optional(),
+    contentId: z.string().optional(),
+  })
+  .refine((data) => data.content !== undefined || data.path !== undefined, {
+    message: 'Either content or path must be provided',
+  });
+
+export type AttachmentInputType = z.infer<typeof AttachmentInputSchema>;
+
+/**
+ * Schema for send options
+ */
+export const SendOptionsSchema = z.object({
+  to: z.union([z.string().email(), z.array(z.string().email())]),
+  cc: z.union([z.string().email(), z.array(z.string().email())]).optional(),
+  bcc: z.union([z.string().email(), z.array(z.string().email())]).optional(),
+  replyTo: z.string().email().optional(),
+  subject: z.string().min(1, 'Subject is required'),
+  text: z.string().optional(),
+  html: z.string().optional(),
+  attachments: z.array(AttachmentInputSchema).optional(),
+  inReplyTo: z.string().optional(),
+  references: z.array(z.string()).optional(),
+  headers: z.record(z.string(), z.string()).optional(),
+});
+
+export type SendOptionsInput = z.infer<typeof SendOptionsSchema>;
+
+/**
+ * Schema for list options when querying emails
+ */
+export const ListOptionsSchema = z.object({
+  folder: z.string().optional(),
+  limit: z.number().int().positive().optional(),
+  offset: z.number().int().nonnegative().optional(),
+  unreadOnly: z.boolean().optional(),
+  from: z.string().optional(),
+  to: z.string().optional(),
+  subject: z.string().optional(),
+  after: z.date().optional(),
+  before: z.date().optional(),
+  hasAttachment: z.boolean().optional(),
+  labels: z.array(z.string()).optional(),
+  query: z.string().optional(),
+});
+
+export type ListOptionsInput = z.infer<typeof ListOptionsSchema>;
+
+/**
+ * Validates send options and returns parsed data
+ * @throws ZodError if validation fails
+ */
+export function validateSendOptions(data: unknown): SendOptionsInput {
+  return SendOptionsSchema.parse(data);
+}
+
+/**
+ * Validates an address and returns parsed data
+ * @throws ZodError if validation fails
+ */
+export function validateAddress(data: unknown): AddressInput {
+  return AddressSchema.parse(data);
+}
+
+/**
+ * Validates list options and returns parsed data
+ * @throws ZodError if validation fails
+ */
+export function validateListOptions(data: unknown): ListOptionsInput {
+  return ListOptionsSchema.parse(data);
+}
+
+/**
+ * Safe validation for send options (returns result object instead of throwing)
+ */
+export function safeParseSendOptions(data: unknown) {
+  return SendOptionsSchema.safeParse(data);
+}
+
+/**
+ * Safe validation for address (returns result object instead of throwing)
+ */
+export function safeParseAddress(data: unknown) {
+  return AddressSchema.safeParse(data);
+}
+
+/**
+ * Safe validation for list options (returns result object instead of throwing)
+ */
+export function safeParseListOptions(data: unknown) {
+  return ListOptionsSchema.safeParse(data);
+}

--- a/packages/zod/tsconfig.json
+++ b/packages/zod/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/zod/tsup.config.ts
+++ b/packages/zod/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  treeshake: true,
+  splitting: false,
+  external: ['zod'],
+});


### PR DESCRIPTION
## Summary
Add `@faktoor/zod` package providing Zod validation schemas for faktoor.js email types.

## Original Prompt
Create PR for issue #18 - Add Zod validation integration with:
- `packages/zod/` folder with package.json, tsconfig.json, tsup.config.ts
- Zod schemas: AddressSchema, SendOptionsSchema, ListOptionsSchema
- Validation helper functions: validateSendOptions(), validateAddress()
- Zod as peer dependency

## Changes Made
- **New package**: `@faktoor/zod` with Zod as peer dependency (^3.0.0)
- **Schemas**:
  - `AddressSchema` - validates email address with optional name
  - `AttachmentInputSchema` - validates attachment input (filename + content/path)
  - `SendOptionsSchema` - validates email send options (to, cc, bcc, subject, etc.)
  - `ListOptionsSchema` - validates email list/query options
- **Validation functions**:
  - `validateSendOptions()` / `safeParseSendOptions()`
  - `validateAddress()` / `safeParseAddress()`
  - `validateListOptions()` / `safeParseListOptions()`
- **Types**: Inferred TypeScript types from schemas

## Test Plan
- [ ] Build passes: `pnpm --filter @faktoor/zod build`
- [ ] Typecheck passes: `pnpm --filter @faktoor/zod typecheck`
- [ ] Install and import in a test project
- [ ] Test validation with valid/invalid data

Closes #18