### PR TITLE
infra: configure branch protection for main branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,24 @@ faktoor.js/
 └── benchmarks/     # Performance tests
 ```
 
+## Branch Protection Rules
+
+The `main` branch has the following protection rules enabled:
+
+| Rule | Status | Description |
+|------|--------|-------------|
+| **Require PR reviews** | ✅ 1 approval | All changes must be reviewed before merging |
+| **Require status checks** | ✅ `build` | CI must pass before merging |
+| **Require up-to-date branch** | ✅ Strict | Branch must be current with `main` |
+| **No direct pushes** | ✅ Enabled | All changes must go through PRs |
+
+### Why These Rules?
+
+- **Code quality** - Reviews catch bugs and ensure code consistency
+- **CI validation** - Automated tests prevent breaking changes
+- **Clean history** - Up-to-date requirement prevents merge conflicts
+- **Audit trail** - PRs document the reasoning behind changes
+
 ## Pull Request Workflow
 
 1. **Fork** the repository
@@ -50,6 +68,8 @@ faktoor.js/
    ```
 5. **Commit** with conventional commits
 6. **Push** and open a PR
+7. **Wait for review** - At least 1 approval required
+8. **Ensure CI passes** - The `build` check must be green
 
 ## Commit Convention
 


### PR DESCRIPTION
## Summary
Configure branch protection rules for the main branch and document them in CONTRIBUTING.md.

## Original Prompt
Configure branch protection for main branch with:
- Require PR reviews (1 approval)
- Require status checks to pass (build)
- Require branches to be up to date
- No direct pushes to main

## Changes Made
- ✅ Configured branch protection via GitHub API
- ✅ Added "Branch Protection Rules" section to CONTRIBUTING.md
- ✅ Updated PR workflow steps to mention review/CI requirements

## Branch Protection Configuration
| Rule | Value |
|------|-------|
| Required approvals | 1 |
| Status checks | `build` (strict) |
| Enforce admins | No |
| Direct pushes | Blocked |

## Test Plan
- [x] Branch protection API call succeeded
- [x] Rules visible in GitHub repo settings
- [ ] Verify direct push to main is blocked
- [ ] Verify PR without approval cannot merge

Closes #12