### PR TITLE
feat(build): add browser-compatible build

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,26 @@ yarn add @faktoor/core @faktoor/gmail
 
 ---
 
+## Browser Usage
+
+faktoor.js supports browser environments out of the box. When using a bundler (Vite, webpack, esbuild), the browser-optimized build is automatically selected.
+
+```typescript
+// Works in browser environments
+import { createMail } from '@faktoor/core';
+import { gmail } from '@faktoor/gmail';
+
+const mail = createMail({
+  provider: gmail({ accessToken: 'your-oauth-access-token' }),
+});
+```
+
+For direct browser usage via CDN or script tags, the browser builds are available at:
+- `@faktoor/core/dist/browser.js`
+- `@faktoor/gmail/dist/browser.js`
+
+---
+
 ## Quick Start
 
 ```typescript

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,10 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "browser": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/browser.js"
+      },
       "import": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,11 +1,22 @@
 import { defineConfig } from 'tsup';
 
-export default defineConfig({
-  entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
-  dts: true,
-  clean: true,
-  sourcemap: true,
-  treeshake: true,
-  splitting: false,
-});
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['esm', 'cjs'],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+    treeshake: true,
+    splitting: false,
+  },
+  {
+    entry: { browser: 'src/index.ts' },
+    format: ['esm'],
+    platform: 'browser',
+    dts: false,
+    sourcemap: true,
+    treeshake: true,
+    splitting: false,
+  },
+]);

--- a/packages/gmail/package.json
+++ b/packages/gmail/package.json
@@ -8,6 +8,10 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "browser": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/browser.js"
+      },
       "import": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"

--- a/packages/gmail/tsup.config.ts
+++ b/packages/gmail/tsup.config.ts
@@ -1,12 +1,24 @@
 import { defineConfig } from 'tsup';
 
-export default defineConfig({
-  entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
-  dts: true,
-  clean: true,
-  sourcemap: true,
-  treeshake: true,
-  splitting: false,
-  external: ['@faktoor/core'],
-});
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['esm', 'cjs'],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+    treeshake: true,
+    splitting: false,
+    external: ['@faktoor/core'],
+  },
+  {
+    entry: { browser: 'src/index.ts' },
+    format: ['esm'],
+    platform: 'browser',
+    dts: false,
+    sourcemap: true,
+    treeshake: true,
+    splitting: false,
+    external: ['@faktoor/core'],
+  },
+]);


### PR DESCRIPTION
## Summary
Add browser-compatible builds for `@faktoor/core` and `@faktoor/gmail` packages, enabling usage in browser environments with bundlers like Vite, webpack, and esbuild.

## Original Prompt
```
Create PR for issue #27 - Add browser-compatible build in ybouhjira/faktoor.js

1. Clone: git clone https://github.com/ybouhjira/faktoor.js.git /tmp/faktoor-browser
2. cd /tmp/faktoor-browser && git checkout -b feat/browser-build
3. Update packages/core/package.json to add browser export
4. Update packages/core/tsup.config.ts
5. Update packages/gmail similarly for browser support
6. Add note in README about browser usage
7. Commit, push, create PR
```

## Changes Made
- Added `browser` export condition to `@faktoor/core` package.json pointing to `./dist/browser.js`
- Added `browser` export condition to `@faktoor/gmail` package.json pointing to `./dist/browser.js`
- Updated `tsup.config.ts` in core package to generate browser-optimized ESM bundle
- Updated `tsup.config.ts` in gmail package to generate browser-optimized ESM bundle
- Added "Browser Usage" section to README with usage examples and CDN paths

## Test Plan
- [ ] Run `pnpm build` to verify browser.js files are generated
- [ ] Import packages in a Vite/webpack project to verify browser condition works
- [ ] Verify existing Node.js imports still work correctly

Closes #27