### PR TITLE
feat(resend): add Resend email sending provider

### DIFF
--- a/packages/resend/package.json
+++ b/packages/resend/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@faktoor/resend",
+  "version": "0.0.1",
+  "description": "Resend email sending provider for faktoor.js",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist coverage .turbo"
+  },
+  "keywords": [
+    "email",
+    "mail",
+    "resend",
+    "faktoor",
+    "typescript"
+  ],
+  "author": "Youssef Bouhjira",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ybouhjira/faktoor.js.git",
+    "directory": "packages/resend"
+  },
+  "peerDependencies": {
+    "resend": "^4.0.0"
+  },
+  "dependencies": {
+    "@faktoor/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^2.1.9",
+    "resend": "^4.0.0",
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/resend/src/index.ts
+++ b/packages/resend/src/index.ts
@@ -1,0 +1,48 @@
+import type { SendOptions, SendResult, EmailId } from '@faktoor/core';
+
+export interface ResendOptions {
+  apiKey: string;
+  baseUrl?: string;
+}
+
+export class ResendProvider {
+  readonly name = 'resend';
+  private apiKey: string;
+  private baseUrl: string;
+
+  constructor(options: ResendOptions) {
+    this.apiKey = options.apiKey;
+    this.baseUrl = options.baseUrl ?? 'https://api.resend.com';
+  }
+
+  async send(options: SendOptions): Promise<SendResult> {
+    const to = Array.isArray(options.to) ? options.to : [options.to];
+    const response = await fetch(`${this.baseUrl}/emails`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: options.headers?.from ?? 'noreply@example.com',
+        to,
+        cc: options.cc,
+        bcc: options.bcc,
+        subject: options.subject,
+        text: options.text,
+        html: options.html,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Resend API error: ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    return { id: data.id as EmailId, timestamp: new Date() };
+  }
+}
+
+export function resend(options: ResendOptions): ResendProvider {
+  return new ResendProvider(options);
+}

--- a/packages/resend/tsconfig.json
+++ b/packages/resend/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/resend/tsup.config.ts
+++ b/packages/resend/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  treeshake: true,
+  splitting: false,
+});

--- a/packages/resend/vitest.config.ts
+++ b/packages/resend/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: ['node_modules', 'dist', '**/*.config.*', '**/*.d.ts'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
Add new `@faktoor/resend` package for sending emails via the Resend API.

## Original Prompt
Add Resend sending service support - Create packages/resend/ with ResendProvider class that implements email sending via Resend API with configurable API key and base URL.

## Changes Made
- Add `packages/resend/package.json` with peerDep on resend
- Add `ResendProvider` class with `send()` method
- Add `resend()` factory function for easy instantiation
- Support for to, cc, bcc, subject, text, html options
- Configurable API key and base URL
- Full TypeScript support with @faktoor/core types
- Add tsconfig.json, tsup.config.ts, vitest.config.ts

## Test Plan
- [ ] Run `pnpm install` to install dependencies
- [ ] Run `pnpm build` to verify build succeeds
- [ ] Manual test with Resend API key

Closes #4